### PR TITLE
 A preconfigured and standardized GitHub CodeSpace for LAN Atlas

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,18 @@
 {
   "name": "lan-atlas-codespace",
   "image": "mcr.microsoft.com/devcontainers/python:3",
-  "features": {
-  },
-    "customizations": {
-		  // Configure properties specific to VS Code.
-		  "vscode": {
-			  // Set *default* container specific settings.json values on container create.
-			  "settings": {
-          "terminal.integrated.defaultProfile.linux": "bash"
-        },
-			  "extensions": [
-          "ms-python.python"
-        ]
-		  },
-  },
+  "features": {},
+  "postCreateCommand": "pip install --upgrade pip && pip install -r requirements-dev.txt",
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "ms-python.python"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "lan-atlas-codespace",
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+  },
+    "customizations": {
+		  // Configure properties specific to VS Code.
+		  "vscode": {
+			  // Set *default* container specific settings.json values on container create.
+			  "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash"
+        },
+			  "extensions": [
+          "ms-python.python"
+        ]
+		  },
+  },
+}


### PR DESCRIPTION
**User Story:**

**As an** inexperienced CSOH software developer
**I need** A preconfigured and standardized GitHub CodeSpace for LAN Atlas
**So that** friction in development is reduced

**Acceptance Criteria:**

- [x] It was configured for the Python programming language
- [x] All VS Code extensions and other dependencies pulled in were vetted and maintained
- [x] requirements-dev.txt was used as the source of truth for software library dependencies
- [x] The CodeSpace was tested for correct Python source code interpretation
- [x] All local secrets and unwanted files are covered by .gitignore.

**Note:** Resolves #11 