### PR TITLE
Create architecture-principals-and-rules

### DIFF
--- a/docs/architecture-principals-and-rules
+++ b/docs/architecture-principals-and-rules
@@ -1,0 +1,19 @@
+##Architecture Principals 
+1.Least Privilege — every component has only the permissions it requires.
+2.Single Responsibility — each module has one clearly defined purpose.
+3.Explicit Over Implicit — avoid hidden behavior and "magic."
+4.Fail Securely — errors should default to a safe state (rollback, deny access, release resources).
+5.Centralized Enforcement — security-critical rules are implemented in one place.
+6.Defense in Depth — don't rely on any single control to prevent failures.
+7.Auditability — every important action should be traceable without exposing sensitive data.
+
+
+
+## Architecture Rules
+No direct DB access from api/ or services/. All DB interaction goes through repositories/. This is the single most important architectural rule for security — it's what keeps SQL confined to one layer and makes injection audits tractable.
+
+1. `api/` calls `services/` only — never `repositories/` or `database/` directly
+2. `services/` calls `repositories/` only — never `database/` directly
+3. `repositories/` calls `database/` only — all SQL lives here
+4. `workers/` follows the same rules as `api/` — calls `services/` only
+5. No raw SQL strings outside `repositories/`

--- a/structure-new
+++ b/structure-new
@@ -1,0 +1,116 @@
+lanatlas/
+    cloud/                              
+        app/
+            schema/
+                schema.sql              
+            migrations/                 
+                env.py
+                versions/
+                    0001_initial_schema.py
+                    0002_add_audit_log.py
+
+            config/
+                identity.py             
+                alerts.py                
+
+            database/
+                pool.py                  
+                db.py                    
+                transaction.py           
+                exceptions.py            
+                audit.py                 
+                logging.py               
+
+            repositories/
+                devices.py               
+                signals.py               
+                observations.py           
+                audit.py                  
+                agents.py                 
+                alerts.py                 
+                users.py                  
+
+            services/
+                identity.py               
+                deduplication.py          
+                classification.py         
+                thresholds.py             
+                oui.py                    
+                alerting.py                
+                devices.py                 
+                alerts.py                  
+                users.py                   
+                agents.py                  
+                sites.py                   
+
+            api/
+                routes/
+                    agents.py              
+                    devices.py
+                    alerts.py
+                    sites.py
+                    auth.py
+                middleware/
+                    auth.py                
+                    rbac.py                
+                    rate_limit.py
+                schemas/
+                    devices.py             
+                    alerts.py              
+                    auth.py     
+					
+			workers/
+                alert_worker.py
+                identity_worker.py
+                cleanup_worker.py
+
+            data/
+                oui.csv                   
+
+        tests/
+            conftest.py                    
+            database/
+                test_db.py
+            repositories/
+                test_devices.py
+                test_observations.py
+                test_signals.py
+                test_audit.py
+            services/
+                test_identity.py           
+                test_deduplication.py
+            workers/
+                test_alert_worker.py
+
+        requirements.txt
+        .env                              
+        .gitignore
+
+    agent/                              
+        scanner.py
+        signer.py
+        buffer.py
+        heartbeat.py
+        collector.py
+        config.py                        
+        tests/
+            test_scanner.py
+            test_signer.py
+            test_buffer.py
+        requirements.txt                 
+        .env                             
+
+    protocol/                         
+        schemas/
+            observation_v1.py           
+            heartbeat_v1.py
+            auth_handshake_v1.py
+        tests/
+            test_observation_schema.py
+        VERSION
+        CHANGELOG.md
+
+    docs/
+        schema-reference.md
+        owasp-controls-mapping.md
+       


### PR DESCRIPTION
This document may server as a guideline for participation in the creation of Lan Atlas. I propose we add a document, architectural-principals-and-rules.txt.

#Architecture Prinicpals 
1.Least Privilege — every component has only the permissions it requires.
2.Single Responsibility — each module has one clearly defined purpose.
3.Explicit Over Implicit — avoid hidden behavior and "magic."
4.Fail Securely — errors should default to a safe state (rollback, deny access, release resources).
5.Centralized Enforcement — security-critical rules are implemented in one place.
6.Defense in Depth — don't rely on any single control to prevent failures.
7.Auditability — every important action should be traceable without exposing sensitive data.



## Architecture Rules
No direct DB access from api/ or services/. All DB interaction goes through repositories/. This is the single most important architectural rule for security — it's what keeps SQL confined to one layer and makes injection audits tractable.

1. `api/` calls `services/` only — never `repositories/` or `database/` directly
2. `services/` calls `repositories/` only — never `database/` directly
3. `repositories/` calls `database/` only — all SQL lives here
4. `workers/` follows the same rules as `api/` — calls `services/` only
5. No raw SQL strings outside `repositories/`